### PR TITLE
Use correct name of the tag for filtering tasks

### DIFF
--- a/src/ticktick_mcp/tools/filter_tools.py
+++ b/src/ticktick_mcp/tools/filter_tools.py
@@ -315,6 +315,23 @@ def _build_property_filter(
             logging.warning(f"Invalid timezone '{tz}' provided. Using local time.")
             # Continue without tz_info
 
+    # Check the correctness of the name of the tag
+    if tag_label:
+        # Retrieve all current tags
+        client = TickTickClientSingleton.get_client()
+        if not client:
+            raise ConnectionError("TickTick client is not available.")
+        client.sync()
+        tags = client.state['tags']
+        for tag in tags:
+            if tag.get("name") == tag_label:
+                break
+            if tag.get("label") == tag_label:
+                # We should use the name of this tag
+                # for the actual filtering
+                tag_label = tag.get("name")
+                break
+
     # Build Period Filters
     due_filter = PeriodFilter(
         start_date=due_start_date,


### PR DESCRIPTION
If a tag is provided to the `ticktick_filter_tasks` tool, the name of the tag should be used for the actual filtering of the tags.
Tags with uppercase letters are only the label of the tag, and is not the (TickTick internal) name of the tag itself.

This PR will lookup the correct name of the tag, based on the tag-string that is provided to the `ticktick_filter_tasks` tool.
This will ensure that filter on the tag is working not matter if the tag-name or the tag-label is provided.